### PR TITLE
fix: Remove .env from repository and add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ data.json
 
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store
+
+# Environment variables
+.env


### PR DESCRIPTION
## Summary
- Added .env to .gitignore to prevent sensitive data from being committed
- Removed .env file from git history for security

## Changes
- Updated .gitignore to include .env file
- Ensures environment variables remain local and secure

## Notes
This is a clean cherry-pick of the .gitignore changes after removing .env from the repository history.

🤖 Generated with [Claude Code](https://claude.ai/code)